### PR TITLE
Don't fail if _data is an empty list

### DIFF
--- a/ProducerConsumerStream/ProducerConsumerStream.cs
+++ b/ProducerConsumerStream/ProducerConsumerStream.cs
@@ -63,7 +63,7 @@ namespace Nito.ProducerConsumerStream
         private bool Empty => _currentBytes == 0;
         private bool Full => _currentBytes == _maxBytes;
         private int AvailableToWrite => _maxBytes - _currentBytes;
-        private int AvailableToRead => _data.First.Value.Length - _headDataBytesRead;
+        private int AvailableToRead => _data.First.Count > 0 ? _data.First.Value.Length - _headDataBytesRead;
         private long WriterPosition { get; set; }
         private long ReaderPosition { get; set; }
 


### PR DESCRIPTION
When `_data.Count == 0`, `data.First` is `null` and `AvailableToRead` would throw a `NullReferenceException`. Return `0` instead.